### PR TITLE
Support unary operators

### DIFF
--- a/tealish/__init__.py
+++ b/tealish/__init__.py
@@ -430,6 +430,7 @@ class Assert(LineStatement):
 
     def process(self):
         self.arg.process(self.get_scope())
+        assert self.arg.type in ('int', 'any'), f'Incorrect type for assert. Expected int, got {self.arg.type}'
         self.write(f'// {self.line}')
         self.write(self.arg.teal())
         if self.message:

--- a/tealish/tealish_expressions.tx
+++ b/tealish/tealish_expressions.tx
@@ -1,14 +1,16 @@
 
-Expression:  Math | Group | FunctionCall | Field | Value;
-Group: ('(' math=Math ')');
-Math: a=Value op=MathOp b=Value;
-MathOp: '+' | '-' | '*' | '/' | '%'
-    | '==' | '>=' | '<=' | '>' | '<' | '!=' | '!'
+Expression:   BinaryOp | UnaryOp | Group | FunctionCall | Field | Value;
+Group: ('(' expression=BinaryOp ')');
+UnaryOp: op=UnaryOperator a=Value;
+UnaryOperator: '!' | '~' | 'b~';
+BinaryOp: a=Value op=BinaryOperator b=Value;
+BinaryOperator: '+' | '-' | '*' | '/' | '%'
+    | '==' | '>=' | '<=' | '>' | '<' | '!='
     | '&&' | '||'
-    | '|' | '%' | '^' | '~'
+    | '|' | '%' | '^'
     | 'b+' | 'b-' | 'b/' | 'b*' | 'b%'
     | 'b==' | 'b!=' | 'b>=' | 'b<=' | 'b>' | 'b<'
-    | 'b|' | 'b&' | 'b^' | 'b~';
+    | 'b|' | 'b&' | 'b^';
 FunctionCall: 
     name=Name 
     ('(' 
@@ -24,7 +26,7 @@ GroupTxnArrayField: 'Gtxn[' index=Expression '].' field=FieldName '[' arrayIndex
 InnerTxnField: 'Itxn.' field=FieldName;
 InnerTxnArrayField: 'Itxn.' field=FieldName '[' arrayIndex=Expression ']';
 GlobalField: 'Global.' field=FieldName;
-Value: FunctionCall | Field | Group | Integer | Bytes | Constant | Variable;
+Value: FunctionCall | Field | UnaryOp | Group | Integer | Bytes | Constant | Variable;
 Variable: name=Name;
 Constant: name=/([A-Z][A-Za-z_0-9]+)/;
 Name: (/([a-z][A-Za-z_0-9]*)/ | /_/);

--- a/tests/test.py
+++ b/tests/test.py
@@ -569,3 +569,97 @@ class TestInnerGroup(unittest.TestCase):
                 'itxn_submit'
             ]
         )
+
+
+class TestOperators(unittest.TestCase):
+
+    def test_binary(self):
+        teal = compile_min([
+            'assert(1 || 2)'
+        ])
+        self.assertEqual(teal, [
+            'pushint 1',
+            'pushint 2',
+            '||',
+            'assert',
+        ])
+
+    def test_unary_literal_int(self):
+        teal = compile_min([
+            'assert(!1)'
+        ])
+        self.assertEqual(teal, [
+            'pushint 1',
+            '!',
+            'assert',
+        ])
+
+    def test_unary_literal_bytes(self):
+        teal = compile_min([
+            'assert(b~"\x00\x00\x00\x00\x00\x00\x00\x00")'
+        ])
+        self.assertEqual(teal, [
+            'pushbytes "\x00\x00\x00\x00\x00\x00\x00\x00"',
+            'b~',
+            'assert',
+        ])
+
+    def test_unary_variable(self):
+        teal = compile_min([
+            'int x = 1',
+            'assert(!x)',
+        ])
+        self.assertEqual(teal, [
+            'pushint 1',
+            'store 0 // x',
+            'load 0 // x',
+            '!',
+            'assert',
+        ])
+
+    def test_unary_functioncall(self):
+        teal = compile_min([
+            'assert(!sqrt(25))',
+        ])
+        self.assertEqual(teal, [
+            'pushint 25',
+            'sqrt',
+            '!',
+            'assert',
+        ])
+
+    def test_unary_group(self):
+        teal = compile_min([
+            'assert(!(0 || 1))',
+        ])
+        self.assertEqual(teal, [
+            'pushint 0',
+            'pushint 1',
+            '||',
+            '!',
+            'assert',
+        ])
+
+    def test_binary_with_unary_b(self):
+        teal = compile_min([
+            'assert(1 || !1)'
+        ])
+        self.assertEqual(teal, [
+            'pushint 1',
+            'pushint 1',
+            '!',
+            '||',
+            'assert',
+        ])
+
+    def test_binary_with_unary_a(self):
+        teal = compile_min([
+            'assert(!1 || 1)'
+        ])
+        self.assertEqual(teal, [
+            'pushint 1',
+            '!',
+            'pushint 1',
+            '||',
+            'assert',
+        ])

--- a/tests/test.py
+++ b/tests/test.py
@@ -207,6 +207,13 @@ class TestAssert(unittest.TestCase):
         teal = compile_min(['int x = balance(0)'])
         self.assertListEqual(teal, ['pushint 0', 'balance', 'store 0 // x'])
 
+    def test_fail_wrong_type(self):
+        with self.assertRaises(CompileError) as e:
+            compile_min([
+                'assert("abc")'
+            ])
+        self.assertIn('Incorrect type for assert. Expected int, got bytes', str(e.exception))
+
 
 class TestFunctionReturn(unittest.TestCase):
 


### PR DESCRIPTION
There are currently a few opcodes that one would expect to use in a operator style (`a opcode b`) rather an a functional style (`opcode(a, b)`) but they are unary rather than binary (1 arg instead of 2). e.g `!`, `~`, `b~`.

This PR adds support for these so we can write stuff like `assert(!x)`.