### PR TITLE
Add loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,25 @@ Functions are used to define reusable pieces of functionality. They can take arg
         OptIn: optin
     end
     ```
+- While Loops
+    ```
+    int x = 0
+    while x < 10:
+        x += 1
+        log(itob(x))
+    end
+    ```
+- For Loops
+    ```
+    for i in 0:10:
+        log(itob(i))
+    end
+    ```
+    ```
+    for _ in 0:10:
+        log("*")
+    end
+    ```
 - InnerTxn
     ```
     inner_txn:

--- a/tealish/__init__.py
+++ b/tealish/__init__.py
@@ -111,6 +111,7 @@ class Node:
                         value = self.matches[name]
                     setattr(self, name, value)
                 except Exception as e:
+                    raise
                     raise ParseError(str(e) + f' at line {self.compiler.line_no}')
 
     def add_child(self, node):
@@ -286,6 +287,8 @@ class Statement(Node):
             return IfStatement.consume(compiler, parent)
         elif line.startswith('while '):
             return WhileStatement.consume(compiler, parent)
+        elif line.startswith('for '):
+            return ForStatement.consume(compiler, parent)
         elif line.startswith('teal:'):
             return Teal.consume(compiler, parent)
         elif line.startswith('inner_group:'):
@@ -644,6 +647,10 @@ class Teal(InlineStatement):
             output += indent(n.reformat())
         output += 'end'
         return output
+    
+    def visit(self):
+        for n in self.nodes:
+            n.visit()
 
 
 class InnerTxnFieldSetter(InlineStatement):
@@ -955,6 +962,92 @@ class WhileStatement(InlineStatement):
         for n in self.nodes:
             n.visit()
         self.write(f'b {self.start_label}')
+        self.write(f'{self.end_label}: // end')
+        self.compiler.level -= 1
+
+    def reformat(self):
+        output = ''
+        output += self.line + '\n'
+        for n in self.nodes:
+            s = n.reformat()
+            if s:
+                output += s + '\n'
+        output += 'end'
+        return output
+
+
+class ForStatement(InlineStatement):
+    possible_child_nodes = [InlineStatement]
+    pattern = r'for (?P<var>[a-z_][a-zA-Z0-9_]*) in (?P<start>[a-zA-Z0-9_]+):(?P<end>[a-zA-Z0-9_]+):$'
+    var: str
+    start: GenericExpression
+    end: GenericExpression
+
+    def __init__(self, line, parent=None, compiler=None) -> None:
+        super().__init__(line, parent, compiler)
+        self.conditional_index = compiler.conditional_count
+        compiler.conditional_count += 1
+        self.start_label = f'l{self.conditional_index}_for'
+        self.end_label = f'l{self.conditional_index}_end'
+
+    @classmethod
+    def consume(cls, compiler, parent):
+        node = ForStatement(compiler.consume_line(), parent, compiler=compiler)
+        while True:
+            if compiler.peek() == 'end':
+                compiler.consume_line()
+                break
+            node.add_child(InlineStatement.consume(compiler, node))
+        return node
+
+    def visit(self):
+        if self.var == '_':
+            self.visit_implicit_counter()
+        else:
+            self.visit_explicit_counter()
+
+    def visit_explicit_counter(self):
+        self.write(f'// {self.line}')
+        self.compiler.level += 1
+        self.start.process(self.get_scope())
+        self.end.process(self.get_scope())
+        self.write(self.start.teal())
+        slot = self.declare_var(self.var, 'int')
+        self.write(f'store {slot} // {self.var}')
+        self.write(f'{self.start_label}:')
+        self.write(f'load {slot} // {self.var}')
+        self.write(self.end.teal())
+        self.write(f'==')
+        self.write(f'bnz {self.end_label}')
+        for n in self.nodes:
+            n.visit()
+        self.write(f'load {slot} // {self.var}')
+        self.write(f'pushint 1')
+        self.write(f'+')
+        self.write(f'store {slot} // {self.var}')
+        self.write(f'b {self.start_label}')
+        self.write(f'{self.end_label}: // end')
+        self.del_var(self.var)
+        self.compiler.level -= 1
+
+    def visit_implicit_counter(self):
+        self.write(f'// {self.line}')
+        self.compiler.level += 1
+        self.start.process(self.get_scope())
+        self.end.process(self.get_scope())
+        self.write(self.start.teal())
+        self.write('dup')
+        self.write(f'{self.start_label}:')
+        self.write(self.end.teal())
+        self.write(f'==')
+        self.write(f'bnz {self.end_label}')
+        for n in self.nodes:
+            n.visit()
+        self.write(f'pushint 1')
+        self.write(f'+')
+        self.write('dup')
+        self.write(f'b {self.start_label}')
+        self.write('pop')
         self.write(f'{self.end_label}: // end')
         self.compiler.level -= 1
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -626,3 +626,54 @@ class TestWhile(unittest.TestCase):
                 'break',
             ])
         self.assertIn('"break" should only be used in a while loop!', str(e.exception))
+
+
+class TestForLoop(unittest.TestCase):
+
+    def test_pass_implicit(self):
+        teal = compile_min([
+            'for _ in 0:10:',
+                'log("a")',
+            'end',
+        ])
+        self.assertListEqual(teal, [
+            'pushint 0',
+            'dup',
+            'l0_for:',
+            'pushint 10',
+            '==',
+            'bnz l0_end',
+            'pushbytes "a"',
+            'log',
+            'pushint 1',
+            '+',
+            'dup',
+            'b l0_for',
+            'pop',
+            'l0_end: // end'
+        ])
+
+
+    def test_pass_explicit(self):
+        teal = compile_min([
+            'for i in 0:10:',
+                'log("a")',
+            'end',
+        ])
+        self.assertListEqual(teal, [
+            'pushint 0',
+            'store 0 // i',
+            'l0_for:',
+            'load 0 // i',
+            'pushint 10',
+            '==',
+            'bnz l0_end',
+            'pushbytes "a"',
+            'log',
+            'load 0 // i',
+            'pushint 1',
+            '+',
+            'store 0 // i',
+            'b l0_for',
+            'l0_end: // end'
+        ])

--- a/tests/test.py
+++ b/tests/test.py
@@ -569,3 +569,60 @@ class TestInnerGroup(unittest.TestCase):
                 'itxn_submit'
             ]
         )
+
+
+class TestWhile(unittest.TestCase):
+
+    def test_pass_simple(self):
+        teal = compile_min([
+            'int x = 1',
+            'while x < 10:',
+                'x = x + 1',
+            'end',
+        ])
+        self.assertListEqual(teal, [
+            'pushint 1',
+            'store 0 // x',
+            'l0_while:',
+            'load 0 // x',
+            'pushint 10',
+            '<',
+            'bz l0_end',
+            'load 0 // x',
+            'pushint 1',
+            '+',
+            'store 0 // x',
+            'b l0_while',
+            'l0_end: // end'
+        ])
+
+    def test_pass_while_break(self):
+        teal = compile_min([
+            'int x = 1',
+            'while 1:',
+                'x = x + 1',
+                'break',
+            'end',
+        ])
+        self.assertListEqual(teal, [
+            'pushint 1',
+            'store 0 // x',
+            'l0_while:',
+            'pushint 1',
+            'bz l0_end',
+            'load 0 // x',
+            'pushint 1',
+            '+',
+            'store 0 // x',
+            'b l0_end',
+            'b l0_while',
+            'l0_end: // end'
+        ])
+
+    def test_fail_break_outside_while(self):
+        with self.assertRaises(ParseError) as e:
+            compile_min([
+                'int x = 1',
+                'break',
+            ])
+        self.assertIn('"break" should only be used in a while loop!', str(e.exception))


### PR DESCRIPTION
This PR adds support for `while` and `for` loops. Includes `break` statement too for breaking out of a while loop.


### While Loops

```
int x = 0
while x < 10:
    x += 1
    log(itob(x))
end
```

### For Loops
```
for i in 0:10:
    log(itob(i))
end
```

This version is more efficient if you are not using the loop counter:

```
for _ in 0:10:
    log("*")
end
```


### Notes:
* The loop counter var `i` is scoped to the loop. It does not exist after the loop.
* The start and end values of `for in` are inclusive.
* The start and end values can be variables but not expressions.
